### PR TITLE
Change wing drop values to be more reasonable

### DIFF
--- a/src/main/kotlin/net/adriantodt/winged/data/WingedConfig.kt
+++ b/src/main/kotlin/net/adriantodt/winged/data/WingedConfig.kt
@@ -106,9 +106,9 @@ class WingedConfig : ConfigData {
         @ConfigEntry.Gui.RequiresRestart
         var requirePlayer: Boolean = true,
         @ConfigEntry.Gui.RequiresRestart
-        var standardChance: Float = 0.05f,
+        var standardChance: Float = 0.001f,
         @ConfigEntry.Gui.RequiresRestart
-        var creativeFlightChance: Float = 0.025f,
+        var creativeFlightChance: Float = 0.0005f,
         @ConfigEntry.Gui.RequiresRestart
         var lootingMultiplier: Float = 0.02f
     )


### PR DESCRIPTION
The wing drop values are far too common while playing normally, as a 1/40 chance for creative flight is way too high.