### PR TITLE
fix Winged bench not being mineable

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,4 @@
+{
+	"replace": false,
+	"values": ["winged:wingbench"]
+}


### PR DESCRIPTION
The bench is taking the End Stone block settings (including `requiresTool`) but is missing an appropriate block tag and thus cannot be mined with any tool.
I put the bench in the "pickaxe mineable" tag, just like `end_stone`.